### PR TITLE
Fix memory issue in model download check

### DIFF
--- a/LLMtest/ContentView.swift
+++ b/LLMtest/ContentView.swift
@@ -883,10 +883,11 @@ class ChatViewModel: ObservableObject {
                 throw URLError(.zeroByteResource)
             }
             
-            // Validate GGUF header
-            let fileData = try Data(contentsOf: tempURL)
-            let header = fileData.prefix(4)
-            guard header == Data([0x47, 0x47, 0x55, 0x46]) else { // "GGUF" magic bytes
+            // Validate GGUF header without loading entire file
+            let handle = try FileHandle(forReadingFrom: tempURL)
+            defer { try? handle.close() }
+            let headerData = try handle.read(upToCount: 4) ?? Data()
+            guard headerData == Data([0x47, 0x47, 0x55, 0x46]) else { // "GGUF" magic bytes
                 throw URLError(.cannotParseResponse)
             }
             


### PR DESCRIPTION
## Summary
- improve GGUF header check to avoid loading huge model files into memory

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6860829fafb8832796392e83645a8fd6